### PR TITLE
"Code Review Test" - Change default target

### DIFF
--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -50,11 +50,11 @@ angular.module('ciuiApp')
 
       codeReview: {
         type: $routeParams['codeReview.type'] || 'github',
-        path: $routeParams['codeReview.path'] || 'sites/all/modules/mymodule'
+        path: $routeParams['codeReview.path'] || 'sites/all/modules/civicrm'
       },
 
       github: {
-        url: $routeParams['github.url'] || 'https://github.com/myuser/myproject'
+        url: $routeParams['github.url'] || 'https://github.com/civicrm/civicrm-core'
       },
 
       gerrit: {


### PR DESCRIPTION
The default target folder is not a valid one. The original
expectation was that you'd want to target your own module,
but it's also useful to target the main Civi repo for
testing, and we can provide that one out of the box.